### PR TITLE
Draft: refactor: keep raw pointer of GstObject instead of a shared_ptr. 

### DIFF
--- a/src/object.hpp
+++ b/src/object.hpp
@@ -118,7 +118,7 @@ template<typename... Args>
 boost::signals2::signal<void(Args...)>& connectGobjectSignal(const std::string& signalName) const;
 
 private:
-  GstObjectSPtr gstObject;
+  GstObject* gstObject;
 
   // SignalConnector to hold Boost.Signals2 signal
   template<typename... Args>

--- a/src/sharedptrs.hpp
+++ b/src/sharedptrs.hpp
@@ -50,6 +50,7 @@ struct GstObjectDeleter
       // Set GstElement state to NULL before unref if it's the last ref to the GstElement
       // This does not work always because setting a pipeline to "playing" increases ref counts.
       // But it is a layer of safety.
+      // TODO: code duplication in @ref Element
       if(GST_IS_ELEMENT(obj) && GST_OBJECT_REFCOUNT(obj) == 1)
       {
         gst_element_set_state(GST_ELEMENT(obj), GST_STATE_NULL);
@@ -123,6 +124,7 @@ using GstPluginFeatureSPtr = std::shared_ptr<GstPluginFeature>;
  * @param obj Raw pointer to the GStreamer object.
  * @param transferType Enum value indicating the ownership transfer type.
  * @return std::shared_ptr<T> A shared pointer to the GStreamer object with a custom deleter.
+ * @todo code duplication, @see Object::Object
  */
 template <typename T>
 std::enable_if_t<IsGstObject<T>::value, std::shared_ptr<T>>

--- a/tests/gtest_element.cpp
+++ b/tests/gtest_element.cpp
@@ -61,6 +61,7 @@ TEST_F(ElementTest, SetState)
   ASSERT_EQ(element->getState(), GST_STATE_PLAYING);
 
   // here we would get a gstreamer error if the Element is destroyed when state != null.
+  // This test may even fail to exit.
 }
 
 TEST_F(ElementTest, GetPads)


### PR DESCRIPTION
… solves a part of #9

Not sure if this should be merged. Currently adds code duplication and currently no use besides #9