### PR TITLE
Remove spdlog dependency and fix nodiscard test warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ https://dragonhillstech.github.io/libdhgst/
 ## Dependencies
 - **GStreamer** (`gstreamer-1.0`, `gstreamer-app-1.0`)
 - **Boost**
-- **spdlog** (when building examples)
 - **CMake 3.10+**
 - **C++17 compiler**
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,7 +5,6 @@ set(EXAMPLES_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/examples)
 
 file(GLOB EXAMPLE_SOURCES "*.cpp")
 
-find_package(spdlog REQUIRED)
 
 # Create a test executable for each test source file
 foreach(EXAMPLE_SOURCE ${EXAMPLE_SOURCES})
@@ -17,7 +16,6 @@ foreach(EXAMPLE_SOURCE ${EXAMPLE_SOURCES})
 
   target_link_libraries(${EXAMPLE_NAME}
           libdhgst ${GSTREAMER_LIBRARIES}
-          spdlog::spdlog
   )
 
   # Set the output directory for the test binary

--- a/examples/pipelineFromDesc.cpp
+++ b/examples/pipelineFromDesc.cpp
@@ -56,7 +56,7 @@ int main(const int argc, const char **argv)
     [mainLoop](const std::string& source, const std::string& errorMessage, const std::string& debugMessage)
     {
       std::cerr << "Error from '" << source << "' | Message: " << errorMessage << " | Debug info: " << debugMessage << std::endl;
-      std:: cerr << "Quitting" << std::endl;
+      std::cerr << "Quitting" << std::endl;
       g_main_loop_quit(mainLoop);
     }
   );

--- a/examples/pipelineFromDesc.cpp
+++ b/examples/pipelineFromDesc.cpp
@@ -12,7 +12,6 @@
 #include "pipeline.hpp"
 #include "messageparser.hpp"
 
-#include <spdlog/spdlog.h>
 
 // std
 #include <iostream>
@@ -33,7 +32,7 @@ int main(const int argc, const char **argv)
 
   const std::string desc = concatArgs(argc, argv);
 
-  spdlog::info(desc);
+  std::cout << desc << std::endl;
 
   gst_init(const_cast<int*>(&argc), const_cast<char***>(&argv));
   auto ppl = dh::gst::Pipeline::fromDescription(desc);
@@ -56,68 +55,65 @@ int main(const int argc, const char **argv)
   messageParser->errorSignal.connect(
     [mainLoop](const std::string& source, const std::string& errorMessage, const std::string& debugMessage)
     {
-      spdlog::error("Error from '{}' | Message: {} | Debug info: {}", source, errorMessage, debugMessage);
-      spdlog::error("Quitting");
+      std::cerr << "Error from '" << source << "' | Message: " << errorMessage << " | Debug info: " << debugMessage << std::endl;
+      std:: cerr << "Quitting" << std::endl;
       g_main_loop_quit(mainLoop);
     }
   );
   messageParser->infoSignal.connect(
     [](const std::string& source, const std::string& infoMessage, const std::string& debugMessage)
     {
-      spdlog::info("Info from '{}' | Message: {} | Debug info: {}", source, infoMessage, debugMessage);
+      std::cout << "Info from '" << source << "' | Message: " << infoMessage << " | Debug info: " << debugMessage << std::endl;
     }
   );
 
   messageParser->warningSignal.connect(
     [](const std::string& source, const std::string& warningMessage, const std::string& debugMessage)
     {
-      spdlog::warn("Warning from '{}' | Message: {} | Debug info: {}", source, warningMessage, debugMessage);
+      std::cout << "Warning from '" << source << "' | Message: " << warningMessage << " | Debug info: " << debugMessage << std::endl;
     }
   );
   messageParser->stateChangedSignal.connect(
     [](const std::string& source, GstState oldState, GstState newState, GstState pendingState)
     {
-      spdlog::info("State change '{}': {} -> {} ({})",
-                   source,
-                   gst_element_state_get_name(oldState),
-                   gst_element_state_get_name(newState),
-                   gst_element_state_get_name(pendingState));
+      std::cout << "State change '" << source << "': "
+                << gst_element_state_get_name(oldState) << " -> "
+                << gst_element_state_get_name(newState) << " ("
+                << gst_element_state_get_name(pendingState) << ")" << std::endl;
     }
   );
   messageParser->endOfStreamSignal.connect(
     [](const std::string& sourceName)
     {
-       spdlog::info("EOS from '{}'", sourceName);
+       std::cout << "EOS from '" << sourceName << "'" << std::endl;
     }
   );
   messageParser->streamStatusSignal.connect(
     [](const std::string& sourceName, GstStreamStatusType statusType, const std::string& ownerName)
     {
-      spdlog::info("Stream status from '{}' | Status Type: {} | Owner: {}",
-             sourceName,
-             dh::gst::helpers::gstStreamStatusTypeToString(statusType),
-             ownerName);
+      std::cout << "Stream status from '" << sourceName << "' | Status Type: "
+                << dh::gst::helpers::gstStreamStatusTypeToString(statusType) << " | Owner: "
+                << ownerName << std::endl;
     }
   );
   messageParser->streamStartSignal.connect(
     [](const std::string& sourceName)
     {
-      spdlog::info("Stream start from '{}'", sourceName);
+      std::cout << "Stream start from '" << sourceName << "'" << std::endl;
     }
   );
   messageParser->asyncDoneSignal.connect(
     [](const std::string& sourceName, GstClockTime runningTime)
     {
-      spdlog::info("Stream status from '{}' | Running time: {}ns",
-       sourceName,
-       runningTime);
+      std::cout << "Stream status from '" << sourceName << "' | Running time: "
+                << runningTime << "ns" << std::endl;
     }
   );
 
   messageParser->elementMessageSignal.connect(
     [](const std::string& sourceName, const GstStructure*)
     {
-      spdlog::info("Element specific message from '{}'", sourceName);
+      std::cout << "Element specific message from '" << sourceName << "'" << std::endl;
     }
   );
 

--- a/tests/test_bin.cpp
+++ b/tests/test_bin.cpp
@@ -106,7 +106,7 @@ BOOST_FIXTURE_TEST_CASE(GetElementByName, BinTest)
   BOOST_CHECK_EQUAL(element2->getGstElement(), element1->getGstElement());
 
   // find not existing
-  BOOST_CHECK_THROW(bin1->getElementByName("DoesNotExist"), std::runtime_error);
+  BOOST_CHECK_THROW((void)bin1->getElementByName("DoesNotExist"), std::runtime_error);
 }
 
 BOOST_FIXTURE_TEST_CASE(GetElementByNameRecurseUp, BinTest)
@@ -121,7 +121,7 @@ BOOST_FIXTURE_TEST_CASE(GetElementByNameRecurseUp, BinTest)
   BOOST_CHECK_EQUAL(element2->getGstElement(), element1->getGstElement());
 
   // find not existing
-  BOOST_CHECK_THROW(bin1->getElementByNameRecurseUp("DoesNotExist"), std::runtime_error);
+  BOOST_CHECK_THROW((void)bin1->getElementByNameRecurseUp("DoesNotExist"), std::runtime_error);
 }
 
 BOOST_FIXTURE_TEST_CASE(FromDescriptionValidPipeline, BinTest)


### PR DESCRIPTION
## Summary
This PR removes the external `spdlog` logging dependency from the codebase, replacing it with standard C++ I/O streams. It also resolves a compiler error in the unit tests caused by ignoring the return value of `[[nodiscard]]` functions.

**Closes #33**

## Changes Made
- **Build System (`CMakeLists.txt`)**: Cleaned up project configuration to drop requirements for `spdlog`.
- **Examples (`examples/pipelineFromDesc.cpp`)**: Swapped out `spdlog::info` for a standard `std::cout` stream.
- **Tests (`tests/test_bin.cpp`)**: Fixed a strict compiler failure (`-Werror=unused-result`) where `BOOST_CHECK_THROW` was implicitly ignoring the `[[nodiscard]]` attribute on `getElementByName` and `getElementByNameRecurseUp`. Fixed by adding explicit `(void)` casting.

## Verification & Testing
- Successfully configured and generated build files with modern CMake.
- Project compiles with no errors or warnings under GCC 16.
- Ran `ctest` locally: **100% tests passed** (10/10 targets succeeded).
- Verified the `pipelineFromDesc` example manually with a standard test pipeline, and it runs correctly.